### PR TITLE
edited content on project overview

### DIFF
--- a/app/views/overview/aorequired.html
+++ b/app/views/overview/aorequired.html
@@ -123,7 +123,7 @@ Academy order required
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">
         <form action="/overview/summary1" method="post">
-  <h1 class="govuk-heading-l">Does this converstion require an academy order?</h1>
+  <h1 class="govuk-heading-l">Does this converstion need an academy order?</h1>
 
 
           {{ govukRadios({

--- a/app/views/overview/opening.html
+++ b/app/views/overview/opening.html
@@ -123,8 +123,8 @@ Set HTB date
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">
         <form action="/overview/summary1" method="post">
-  <h1 class="govuk-heading-l">Change date for academy opening</h1>
-<p>All acadamies must open on the 1st of the month. Once you have created a new opening date please make sure you inform the applicant of the change.</p>
+  <h1 class="govuk-heading-l">Set the opening date for the academy</h1>
+<p>Acadamies must open on the first day of every month. You should tell the school and the trust what the opening date will be if you change it.</p>
 
           {{ govukRadios({
             idPrefix: "opening-date",

--- a/app/views/overview/recommendation.html
+++ b/app/views/overview/recommendation.html
@@ -123,7 +123,7 @@ Academy order required
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">
         <form action="/overview/summary1" method="post">
-  <h1 class="govuk-heading-l">Do you recomend this conversion?</h1>
+  <h1 class="govuk-heading-l">What is your recommendation for this project?</h1>
 
 
           {{ govukRadios({
@@ -133,12 +133,16 @@ Academy order required
             items: [
        
               {
-                value: "Yes",
-                text: "Yes"
+                value: "Approve",
+                text: "Approve"
               },
               {
-                value: "No",
-                text: "No"
+                value: "Defer",
+                text: "Defer"
+              },
+              {
+                value: "Decline",
+                text: "Decline"
               }
               
             ]

--- a/app/views/overview/set-htb.html
+++ b/app/views/overview/set-htb.html
@@ -123,9 +123,9 @@ Set HTB date
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">
         <form action="/overview/summary1" method="post" novalidate>
-  <h1 class="govuk-heading-l">Set date for headteacherbaord</h1>
+  <h1 class="govuk-heading-l">Choose the HTB date for this project</h1>
 
-  <p>Use the information in the <a href="/related/application">application form</a> to help you best determind the best date for headteacher board.</p>
+  <p>Read through the <a href="/related/application">application form</a> to help you choose the best HTB date to aim for.</p>
           {{ govukRadios({
             idPrefix: "htb-date",
             name: "htb-date",

--- a/app/views/overview/summary1.html
+++ b/app/views/overview/summary1.html
@@ -149,7 +149,7 @@ Rationale
           </div>
           <div class="govuk-summary-list__row">
             <dt class="govuk-summary-list__key">
-              Is AO required?
+              Is an AO (academy order) required?
             </dt>
             <dd class="govuk-summary-list__value">
             {{ data["aorequired"] }}
@@ -179,21 +179,70 @@ Rationale
           </div>
           <div class="govuk-summary-list__row">
             <dt class="govuk-summary-list__key">
-             Project name
+             School name
             </dt>
             <dd class="govuk-summary-list__value">
-              <p class="govuk-body">St. Wilfred's Primary School (120620) Warrington</p>
+              <p class="govuk-body">St. Wilfred's Primary School</p>
             </dd>
             <dd class="govuk-summary-list__actions">
-           
             </dd>
           </div>
           <div class="govuk-summary-list__row">
             <dt class="govuk-summary-list__key">
-             Name of MAT/Sponsor
+             URN (unique reference number)
             </dt>
             <dd class="govuk-summary-list__value">
-              <p class="govuk-body">TRO89764576 Dynamics Academy</p>
+              <p class="govuk-body">120620</p>
+            </dd>
+            <dd class="govuk-summary-list__actions">
+            </dd>
+          </div>
+          <div class="govuk-summary-list__row">
+            <dt class="govuk-summary-list__key">
+             Local authority
+            </dt>
+            <dd class="govuk-summary-list__value">
+              <p class="govuk-body">Warrington</p>
+            </dd>
+            <dd class="govuk-summary-list__actions">
+            </dd>
+          </div>
+          <div class="govuk-summary-list__row">
+            <dt class="govuk-summary-list__key">
+             Trust reference number
+            </dt>
+            <dd class="govuk-summary-list__value">
+              <p class="govuk-body">TRO1318</p>
+            </dd>
+            <dd class="govuk-summary-list__actions">
+            </dd>
+          </div>
+          <div class="govuk-summary-list__row">
+            <dt class="govuk-summary-list__key">
+             Name of trust/sponsor
+            </dt>
+            <dd class="govuk-summary-list__value">
+              <p class="govuk-body">Dynamics Trust</p>
+            </dd>
+            <dd class="govuk-summary-list__actions">
+            </dd>
+          </div>
+          <div class="govuk-summary-list__row">
+            <dt class="govuk-summary-list__key">
+            Sponsor reference number
+            </dt>
+            <dd class="govuk-summary-list__value">
+              <p class="govuk-body">SP00170</p>
+            </dd>
+            <dd class="govuk-summary-list__actions">
+            </dd>
+          </div>
+          <div class="govuk-summary-list__row">
+            <dt class="govuk-summary-list__key">
+            Sponsor name
+            </dt>
+            <dd class="govuk-summary-list__value">
+              <p class="govuk-body">Diocese of Warrington</p>
             </dd>
             <dd class="govuk-summary-list__actions">
             </dd>
@@ -203,7 +252,7 @@ Rationale
              Academy type and route
             </dt>
             <dd class="govuk-summary-list__value">
-              <p class="govuk-body">Conversion grant only £2000 convertor</p>
+              <p class="govuk-body">Converter, grant only £25000</p>
             </dd>
             <dd class="govuk-summary-list__actions">
             </dd>


### PR DESCRIPTION
Wrote our acronyms for AO
Edited the questions and hint text in each editable task
Added extra fields to the project overview page: School name, URN, Local authority, Trust name, Trust reference number, Sponsor name and sponsor reference number
This makes the labelling clearer and provides one field per label instead of many data points stuffed into one field.