### PR TITLE
Edited task list and conversion overview

### DIFF
--- a/app/views/overview/summary1.html
+++ b/app/views/overview/summary1.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
     <title>
-Rationale
+Conversion overview
 </title>
     <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
     <meta name="theme-color" content="#0b0c0c"> 
@@ -117,7 +117,7 @@ Rationale
     <div class="govuk-grid-column-full">
 
       <h1 class="govuk-heading-l">
-        Project overview</h1>
+        Conversion overview</h1>
         <dl class="govuk-summary-list">
           <div class="govuk-summary-list__row">
             <dt class="govuk-summary-list__key">
@@ -149,7 +149,7 @@ Rationale
           </div>
           <div class="govuk-summary-list__row">
             <dt class="govuk-summary-list__key">
-              Is an AO (academy order) required?
+              Is an academy order (AO) required?
             </dt>
             <dd class="govuk-summary-list__value">
             {{ data["aorequired"] }}
@@ -189,7 +189,7 @@ Rationale
           </div>
           <div class="govuk-summary-list__row">
             <dt class="govuk-summary-list__key">
-             URN (unique reference number)
+             Unique reference number (URN)
             </dt>
             <dd class="govuk-summary-list__value">
               <p class="govuk-body">120620</p>
@@ -219,7 +219,7 @@ Rationale
           </div>
           <div class="govuk-summary-list__row">
             <dt class="govuk-summary-list__key">
-             Name of trust/sponsor
+             Name of trust or sponsor
             </dt>
             <dd class="govuk-summary-list__value">
               <p class="govuk-body">Dynamics Trust</p>

--- a/app/views/task_list1.html
+++ b/app/views/task_list1.html
@@ -161,7 +161,7 @@
 <div class="govuk-grid-column-two-thirds">
       <h2 class="govuk-heading-l govuk-!-margin-bottom-2">Task list</h2>
 
-      <p class="govuk-body">The task list will help you fill out your HTB (headteacher board) template. You can complete each task in any order and the infromation you fill out will populate into the template.</p>
+      <p class="govuk-body">The task list will help you fill out your headteacher board (HTB) template. You can complete each task in any order and the infromation you fill out will populate into the template.</p>
       <p> Some of the information is already pre-populated from TRAMS and the application form. You can use this as a guide to help you assess the school and trust.</p>
    <ol class="app-task-list">
           <!--  <li>
@@ -188,13 +188,13 @@
 
         <li>
           <h2 class="app-task-list__section">
-        Create HTB template
+        Create headteacher board (HTB) template
           </h2>
           <ol class="app-task-list govuk-!-margin-bottom-8">
             <li class="app-task-list__item">
               <span class="app-task-list__task-name">
                 <a href="overview/summary1.html" aria-describedby="company-information-status">
-                  Project overview
+                  Conversion overview
                 </a>
               </span>
               {% if data['overview-status']%} 
@@ -283,13 +283,13 @@
 
         <li>
           <h2 class="app-task-list__section">
-            Trust/sponsor template
+            Trust or sponsor template
           </h2>
           <ol class="app-task-list govuk-!-margin-bottom-8">
             <li class="app-task-list__item">
               <span class="app-task-list__task-name">
                 <a href="#" aria-describedby="eligibility-status">
-                  Check and edit trust/sponsor template
+                  Check and edit the trust or sponsor template
                 </a>
               </span>
               <strong class="govuk-tag govuk-tag--grey app-task-list__tag" id="sponsor-template">Not Started</strong>


### PR DESCRIPTION
- followed style guidelines of writing out acronym meaning before the acronym in brackets
- changed 'Project overview' to 'Conversion overview' to be clearer
- 'Changed title of summary page to 'Conversion overview'