### PR TITLE
General info and rationale content edits

### DIFF
--- a/app/views/general-info/diocesan.html
+++ b/app/views/general-info/diocesan.html
@@ -123,7 +123,7 @@ Diocesan MAT
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">
         <form action="/general-info/summary1" method="post">
-  <h1 class="govuk-heading-l">Is this a diocesan MAT (multi-academy trust)?</h1>
+  <h1 class="govuk-heading-l">Is this a diocesan multi-academy trust (MAT)?</h1>
 
 
 

--- a/app/views/general-info/summary1.html
+++ b/app/views/general-info/summary1.html
@@ -152,7 +152,7 @@
           </div>
           <div class="govuk-summary-list__row">
             <dt class="govuk-summary-list__key">
-             NOR (number on roll)
+             Number on roll (NOR)
             </dt>
             <dd class="govuk-summary-list__value">
              105
@@ -184,7 +184,7 @@
           </div>
           <div class="govuk-summary-list__row">
             <dt class="govuk-summary-list__key">
-            PAN (published admissions number)
+            Published admissions number (PAN)
             </dt>
             <dd class="govuk-summary-list__value">
               <p class="govuk-body">30</p>
@@ -194,7 +194,7 @@
           </div>
           <div class="govuk-summary-list__row">
             <dt class="govuk-summary-list__key">
-             Percentage of free school meals at the school
+             Percentage of free school meals at the school (%FSM)
             </dt>
             <dd class="govuk-summary-list__value">
             23.8%
@@ -206,7 +206,7 @@
 
           <div class="govuk-summary-list__row">
             <dt class="govuk-summary-list__key">
-             Part of a PFI (private finance initiative) scheme
+             Part of a private finance initiative (PFI) scheme
             </dt>
             <dd class="govuk-summary-list__value">
             No
@@ -243,7 +243,7 @@
               </div>
               <div class="govuk-summary-list__row">
                 <dt class="govuk-summary-list__key">
-                 Is this a Diocesan MAT (multi-academy trust)?
+                 Is this a Diocesan multi-academy trust (MAT)?
                 </dt>
                 <dd class="govuk-summary-list__value">
                   {{ data['diocesan'] }}
@@ -289,7 +289,7 @@
                 MP details
                 </dt>
                 <dd class="govuk-summary-list__value">
-                 Gregg Davies - Warrington South
+                 Gregg Davies, Warrington South
                 </dd>
                 <dd class="govuk-summary-list__actions">
                   

--- a/app/views/general-info/viability.html
+++ b/app/views/general-info/viability.html
@@ -123,7 +123,7 @@ Viability issues
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">
         <form action="/general-info/summary1" method="post">
-  <h1 class="govuk-heading-l">Are there viability issues at the school?</h1>
+  <h1 class="govuk-heading-l">Is the school viable to convert?</h1>
 
   <details class="govuk-details" data-module="govuk-details">
     <summary class="govuk-details__summary">

--- a/app/views/rationale/rationale-summary1.html
+++ b/app/views/rationale/rationale-summary1.html
@@ -134,7 +134,7 @@
           </div>
           <div class="govuk-summary-list__row">
             <dt class="govuk-summary-list__key">
-              Rationale for trust/sponsor
+              Rationale for the trust or sponsor
             </dt>
             <dd class="govuk-summary-list__value">
               {% if data['trust-rationale']%}

--- a/app/views/rationale/sponsor-rationale.html
+++ b/app/views/rationale/sponsor-rationale.html
@@ -115,12 +115,12 @@ Sponsor rationale
           
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-<h1 class="govuk-heading-l">Write the rationale for the trust/sponsor</h1>
+<h1 class="govuk-heading-l">Write the rationale for the trust or sponsor</h1>
 <p>Explain why the trust is a good match for the school.</p>
       <details class="govuk-details" data-module="govuk-details">
         <summary class="govuk-details__summary">
           <span class="govuk-details__summary-text">
-            Help with writing a trust/sponsor rationale
+            Help with writing a trust or sponsor rationale
           </span>
         </summary>
         <div class="govuk-details__text">


### PR DESCRIPTION
- removed '/' from trust/sponsor, replaced with trust or sponsor
- rewrote acronyms to have the meaning first followed by the acronym in brackets