### PR TITLE
Added hint text to 2 tasks

### DIFF
--- a/app/views/general-info/distance.html
+++ b/app/views/general-info/distance.html
@@ -127,6 +127,9 @@ Distance from MAT HQ
   {% from "govuk/components/input/macro.njk" import govukInput %}
 
   {{ govukInput({
+    hint: {
+      text: "Answer in miles. For example, 25.3 miles"
+    },
 
     classes: "govuk-input--width-5",
     id: "distance",

--- a/app/views/general-info/goodschools.html
+++ b/app/views/general-info/goodschools.html
@@ -126,6 +126,9 @@ Percentage of good or outstanding schools
   {% from "govuk/components/input/macro.njk" import govukInput %}
 
   {{ govukInput({
+    hint: {
+      text: "For example, 65%"
+    },
 
     classes: "govuk-input--width-3",
     id: "goodschools",

--- a/app/views/preview-templates/preview.html
+++ b/app/views/preview-templates/preview.html
@@ -197,10 +197,10 @@ Preview HTB
         <tr class="govuk-table__row">
           <td class="govuk-table__cell"><strong>Deficit:</strong> Yes</td>
           <td class="govuk-table__cell"><strong>Is this a Diocesean multi-academy trust (MAT)?</strong> Yes</td>
-          <td class="govuk-table__cell"><strong>If yes percentage of schools that are Good or Outstanding?</strong> 85%, RSC Breifing tool - 16.10.20</td>
+          <td class="govuk-table__cell"><strong>If yes percentage of schools that are Good or Outstanding?</strong> {{ data['goodschools']}}</td>
         </tr>
         <tr>
-          <td class="govuk-table__cell"><strong>Distance to proposed <abbr title="multi-academy trust">MAT</abbr> or Sponsor:</strong> {{ data['distance']}} </td>
+          <td class="govuk-table__cell"><strong>Distance to proposed MAT or Sponsor:</strong> {{ data['distance']}} </td>
           <td class="govuk-table__cell"><strong>MP:</strong> Greg Davies, MP Conservative</td>
           <td class="govuk-table__cell"></td>
 


### PR DESCRIPTION
Added hint text to 'Percentage of schools good and outstanding' and to 'distance to trust HQ' question

Also fixed the data field in the preview section to the answer for 'Percentage of outstanding school' question pulls through.