### PR TITLE
Updates key stage labels

### DIFF
--- a/app/views/generate/generate_summary.html
+++ b/app/views/generate/generate_summary.html
@@ -786,14 +786,14 @@ Early years provision
   </div>
 </section> 
 <h2 class="govuk-heading-m">
-Key stage (KS) performance tables
+Key stage performance tables
   </h2>
 <section class="app-summary-card govuk-!-margin-bottom-6">
   
   <header class="app-summary-card__header">
     
     <h2 class="app-summary-card__title">
-     KS2 2019
+     2019 key stage 2
     </h2>
   </header>
   <div class="app-summary-card__body">
@@ -843,7 +843,7 @@ Key stage (KS) performance tables
   <header class="app-summary-card__header">
     
     <h2 class="app-summary-card__title">
-     KS2 2018
+     2018 key stage 2
     </h2>
   </header>
   <div class="app-summary-card__body">
@@ -894,7 +894,7 @@ Key stage (KS) performance tables
   <header class="app-summary-card__header">
     
     <h2 class="app-summary-card__title">
-     KS2 2017
+     2017 key stage 2
     </h2>
   </header>
   <div class="app-summary-card__body">

--- a/app/views/key-stage/key-stage-performance-tables.html
+++ b/app/views/key-stage/key-stage-performance-tables.html
@@ -111,10 +111,10 @@ Key stage performance tables
       <div class="govuk-width-container"><a href="javascript:history.back();" class="govuk-back-link">Back</a>
 <main class="govuk-main-wrapper gov-main-wrapper--auto-spacing" id="main-content" role="main">
 
-  <h1 class="govuk-heading-l">Key stage (KS) performance tables</h1>
+  <h1 class="govuk-heading-l">Key stage performance tables</h1>
   <p class="govuk-body govuk-!-margin-bottom-7">This information comes from TRAMS and the table will populate into your HTB template.</p>
   <table class="govuk-table">
-    <caption class="govuk-table__caption govuk-table__caption--l">KS2 2019</caption>
+    <caption class="govuk-table__caption govuk-table__caption--l">2019 key stage 2</caption>
     <tbody class="govuk-table__body">
         <th scope="row" class="govuk-table__cell"></th>
         <th scope="row" class="govuk-table__cell">% meeting expected standard in RWM (PP)</th>
@@ -151,7 +151,7 @@ Key stage performance tables
    </tbody></table>
 <br>
    <table class="govuk-table">
-    <caption class="govuk-table__caption govuk-table__caption--l">KS2 2018</caption>
+    <caption class="govuk-table__caption govuk-table__caption--l">2018 key stage 2</caption>
     <th scope="row" class="govuk-table__cell"></th>
     <th scope="row" class="govuk-table__cell">% meeting expected standard in RWM (PP)</th>
     <th scope="row" class="govuk-table__cell">% meeting higher standard in RWM (PP)</th>
@@ -187,7 +187,7 @@ Key stage performance tables
 </tbody></table>
 <br>
 <table class="govuk-table">
-<caption class="govuk-table__caption govuk-table__caption--l">KS2 2017</caption>
+<caption class="govuk-table__caption govuk-table__caption--l">2017 key stage 2</caption>
 <th scope="row" class="govuk-table__cell"></th>
 <th scope="row" class="govuk-table__cell">% meeting expected standard in RWM (PP)</th>
 <th scope="row" class="govuk-table__cell">% meeting higher standard in RWM (PP)</th>

--- a/app/views/task_list1.html
+++ b/app/views/task_list1.html
@@ -221,7 +221,7 @@
         <li class="app-task-list__item">
           <span class="app-task-list__task-name">
             <a href="/key-stage/key-stage-performance-tables.html" aria-describedby="performance-tables">
-              Key stage (KS) performance tables
+              Key stage performance tables
             </a>
           </span>
           <strong class="govuk-tag govuk-tag--grey app-task-list__tag" id="performance-tables">Reference only</strong>


### PR DESCRIPTION
Put the year in front of each header to differentiate each table quicker if someone was scanning them